### PR TITLE
+focus on show/hide translation; +learned words number

### DIFF
--- a/src/assets/components/FlippingCards.jsx
+++ b/src/assets/components/FlippingCards.jsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
 import ArrowBack from "@mui/icons-material/ArrowBack";
 import ArrowForward from "@mui/icons-material/ArrowForward";
 import IconButton from "@mui/material/IconButton";
@@ -29,6 +31,7 @@ export default function FlippingCards(props) {
   // Мы будем хранить карточки, для которых пользователь открыл перевод во внутреннем состоянии этого компонента
   // это состояние, которое мы поднимаем из карточек показа слов WordCardView
   const [showTranslationList, setShowTranslation] = React.useState([]);
+  const [learnedWordsList, setLearnedWords] = React.useState([]);
 
   function handleShowHideTranslation(cardId) {
     setShowTranslation(
@@ -37,8 +40,12 @@ export default function FlippingCards(props) {
         return Utilities.UpdateArray(prevState, cardId);
       }
     );
+    setLearnedWords((prevState) => {
+      return Utilities.PushToArray(prevState, cardId);
+    });
   }
 
+  const learnedWordsNumber = learnedWordsList.length || 0;
   return (
     <>
       {!listLength ? (
@@ -48,6 +55,11 @@ export default function FlippingCards(props) {
         ></NothingFound>
       ) : (
         <>
+          <Alert severity="success">
+            <AlertTitle>Wow!</AlertTitle>
+            You've learned <strong>{learnedWordsNumber}</strong> words!
+          </Alert>
+
           <Box
             sx={{
               justifyContent: "center",
@@ -124,6 +136,7 @@ export default function FlippingCards(props) {
                   key={wCard.id}
                   showTranslationFlag={showTranslationList.includes(wCard.id)}
                   onShowHideTranslation={handleShowHideTranslation}
+                  disableAutoFocus={true}
                 />
               </Box>
             ))}

--- a/src/assets/components/WordCardView.jsx
+++ b/src/assets/components/WordCardView.jsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
+import TrapFocus from "@mui/base/TrapFocus";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
@@ -14,7 +15,9 @@ export default function WordCardView(props) {
     showTranslationFlag,
     id,
     onShowHideTranslation,
+    disableAutoFocus = false,
   } = props;
+
   //   передаем в компонент состояние - показывать перевод или нет
   //   в зависимости от этого признака будем показывать или скрывать перевод и транскрипцию, по дефолту - скрыто
   const [showTranslation, setShowTranslation] = React.useState(
@@ -45,15 +48,31 @@ export default function WordCardView(props) {
               {transcription}
             </Typography>
             <Typography variant="body2">{russian}</Typography>
-            <IconButton aria-label="hide" onClick={handleShowTranslation}>
-              <ShowTranslIcon sx={{ transform: "rotate(180deg)" }} />
-            </IconButton>
+            {!disableAutoFocus ? (
+              <TrapFocus open>
+                <IconButton aria-label="hide" onClick={handleShowTranslation}>
+                  <ShowTranslIcon sx={{ transform: "rotate(180deg)" }} />
+                </IconButton>
+              </TrapFocus>
+            ) : (
+              <IconButton aria-label="hide" onClick={handleShowTranslation}>
+                <ShowTranslIcon sx={{ transform: "rotate(180deg)" }} />
+              </IconButton>
+            )}
           </Box>
         ) : (
           <Box component="div">
-            <IconButton aria-label="show" onClick={handleShowTranslation}>
-              <ShowTranslIcon />
-            </IconButton>
+            {!disableAutoFocus ? (
+              <TrapFocus open>
+                <IconButton aria-label="show" onClick={handleShowTranslation}>
+                  <ShowTranslIcon />
+                </IconButton>
+              </TrapFocus>
+            ) : (
+              <IconButton aria-label="show" onClick={handleShowTranslation}>
+                <ShowTranslIcon />
+              </IconButton>
+            )}
           </Box>
         )}
       </CardContent>

--- a/src/assets/utilities/Utilities.js
+++ b/src/assets/utilities/Utilities.js
@@ -1,5 +1,6 @@
 export default class Utilities {
   static UpdateArray(arr, elem) {
+    // добавить элемент в массив, если его там нет. Удалить, если он там есть.
     let ind = arr.indexOf(elem);
 
     if (ind === -1) {
@@ -9,6 +10,7 @@ export default class Utilities {
     }
   }
   static PushToArray(arr, elem) {
+    // добавить элемент в массив только если его там нет
     let ind = arr.indexOf(elem);
 
     if (ind === -1) {


### PR DESCRIPTION
решение с фокусом на показ-скрытие перевода сделано средствами mui, но не очень мне нравится. Хочется условный рендеринг как то сделать для параметра disableAutoFocus, который есть там в TrapFocus, но пока не могу понять, как это сделать.
появился подсчет количества слов, которые только что изучены. Решение тоже в лоб. Возможно, визуализация по крайней мере будет посимпатичнее. Нужно подумать.